### PR TITLE
Add LM Studio streaming example and replace prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git clone https://github.com/resemble-ai/chatterbox.git
 cd chatterbox
 pip install -e .
 ```
-We developed and tested Chatterbox on Python 3.11 on Debain 11 OS; the versions of the dependencies are pinned in `pyproject.toml` to ensure consistency. You can modify the code or dependencies in this installation mode.
+We developed and tested Chatterbox on Python 3.11 on Debian 11 OS; the versions of the dependencies are pinned in `pyproject.toml` to ensure consistency. You can modify the code or dependencies in this installation mode.
 
 
 # Usage
@@ -69,10 +69,14 @@ AUDIO_PROMPT_PATH = "YOUR_FILE.wav"
 wav = model.generate(text, audio_prompt_path=AUDIO_PROMPT_PATH)
 ta.save("test-2.wav", wav, model.sr)
 ```
-See `example_tts.py` and `example_vc.py` for more examples.
+See `example_tts.py`, `example_vc.py`, and `lm_studio_chat_audio.py` for more examples.
 
-# Supported Lanugage
-Currenlty only English.
+```bash
+python lm_studio_chat_audio.py
+```
+
+# Supported Language
+Currently only English.
 
 # Acknowledgements
 - [Cosyvoice](https://github.com/FunAudioLLM/CosyVoice)

--- a/lm_studio_chat_audio.py
+++ b/lm_studio_chat_audio.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import requests
+import sounddevice as sd
+import numpy as np
+import torch
+
+from chatterbox.tts import ChatterboxTTS
+
+LLM_ENDPOINT = "http://localhost:1234/v1/chat/completions"
+HEADERS = {"Content-Type": "application/json"}
+
+logger = logging.getLogger(__name__)
+
+
+def stream_chat(prompt: str):
+    payload = {
+        "model": "local-model",
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": True,
+    }
+    with requests.post(LLM_ENDPOINT, json=payload, headers=HEADERS, stream=True) as r:
+        for line in r.iter_lines():
+            if not line:
+                continue
+            if line.startswith(b"data: "):
+                line = line[len(b"data: ") :]
+            if line.strip() == b"[DONE]":
+                break
+            data = json.loads(line.decode("utf-8"))
+            delta = data["choices"][0]["delta"]
+            yield delta.get("content", "")
+
+
+def speak_stream(token_stream, tts_model: ChatterboxTTS):
+    buffer = ""
+    for token in token_stream:
+        buffer += token
+        if token.endswith((".", "?", "!")):
+            logger.info("Synthesizing: %s", buffer)
+            audio = tts_model.generate(buffer).squeeze(0).numpy()
+            sd.play(audio, tts_model.sr)
+            sd.wait()
+            buffer = ""
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    model = ChatterboxTTS.from_pretrained(device="cuda" if torch.cuda.is_available() else "cpu")
+    prompt = "Hello! How do you feel today?"
+    speak_stream(stream_chat(prompt), model)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chatterbox/models/s3gen/hifigan.py
+++ b/src/chatterbox/models/s3gen/hifigan.py
@@ -18,6 +18,7 @@
 """HIFI-GAN"""
 
 from typing import Dict, Optional, List
+import logging
 import numpy as np
 from scipy.signal import get_window
 import torch
@@ -31,6 +32,7 @@ from torch import nn, sin, pow
 from torch.nn import Parameter
 
 
+logger = logging.getLogger(__name__)
 class Snake(nn.Module):
     '''
     Implementation of a sine-based periodic activation function
@@ -380,7 +382,7 @@ class HiFTGenerator(nn.Module):
         self.f0_predictor = f0_predictor
 
     def remove_weight_norm(self):
-        print('Removing weight norm...')
+        logging.info('Removing weight norm...')
         for l in self.ups:
             remove_weight_norm(l)
         for l in self.resblocks:

--- a/src/chatterbox/models/s3gen/s3gen.py
+++ b/src/chatterbox/models/s3gen/s3gen.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+logger = logging.getLogger(__name__)
 
 import numpy as np
 import torch
@@ -122,7 +123,7 @@ class S3Token2Mel(torch.nn.Module):
             ref_wav = ref_wav.unsqueeze(0)  # (B, L)
 
         if ref_wav.size(1) > 10 * ref_sr:
-            print("WARNING: cosydec received ref longer than 10s")
+            logging.warning("cosydec received ref longer than 10s")
 
         ref_wav_24 = ref_wav
         if ref_sr != S3GEN_SR:

--- a/src/chatterbox/models/s3gen/utils/mel.py
+++ b/src/chatterbox/models/s3gen/utils/mel.py
@@ -1,7 +1,10 @@
 """mel-spectrogram extraction in Matcha-TTS"""
 from librosa.filters import mel as librosa_mel_fn
+import logging
 import torch
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 # NOTE: they decalred these global vars
@@ -43,9 +46,9 @@ def mel_spectrogram(y, n_fft=1920, num_mels=80, sampling_rate=24000, hop_size=48
         y = y[None, ]
 
     if torch.min(y) < -1.0:
-        print("min value is ", torch.min(y))
+        logging.warning("min value is %s", torch.min(y))
     if torch.max(y) > 1.0:
-        print("max value is ", torch.max(y))
+        logging.warning("max value is %s", torch.max(y))
 
     global mel_basis, hann_window  # pylint: disable=global-statement,global-variable-not-assigned
     if f"{str(fmax)}_{str(y.device)}" not in mel_basis:

--- a/src/chatterbox/tts.py
+++ b/src/chatterbox/tts.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
+import logging
 
 import librosa
 import torch
@@ -17,6 +18,8 @@ from .models.t3.modules.cond_enc import T3Cond
 
 
 REPO_ID = "ResembleAI/chatterbox"
+
+logger = logging.getLogger(__name__)
 
 
 def punc_norm(text: str) -> str:
@@ -169,9 +172,9 @@ class ChatterboxTTS:
         # Check if MPS is available on macOS
         if device == "mps" and not torch.backends.mps.is_available():
             if not torch.backends.mps.is_built():
-                print("MPS not available because the current PyTorch install was not built with MPS enabled.")
+                logging.warning("MPS not available because the current PyTorch install was not built with MPS enabled.")
             else:
-                print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
+                logging.warning("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
             device = "cpu"
 
         for fpath in ["ve.safetensors", "t3_cfg.safetensors", "s3gen.safetensors", "tokenizer.json", "conds.pt"]:

--- a/src/chatterbox/vc.py
+++ b/src/chatterbox/vc.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import logging
+logger = logging.getLogger(__name__)
 
 import librosa
 import torch
@@ -63,9 +65,9 @@ class ChatterboxVC:
         # Check if MPS is available on macOS
         if device == "mps" and not torch.backends.mps.is_available():
             if not torch.backends.mps.is_built():
-                print("MPS not available because the current PyTorch install was not built with MPS enabled.")
+                logging.warning("MPS not available because the current PyTorch install was not built with MPS enabled.")
             else:
-                print("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
+                logging.warning("MPS not available because the current MacOS version is not 12.3+ and/or you do not have an MPS-enabled device on this machine.")
             device = "cpu"
             
         for fpath in ["s3gen.safetensors", "conds.pt"]:


### PR DESCRIPTION
## Summary
- clean up README typos
- log warnings instead of printing in the model
- provide new `lm_studio_chat_audio.py` example for LM Studio chat streaming
- document the example in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af9ba021c83298fcde0ce5590cc72